### PR TITLE
Adding a capture charge endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ pin.createCustomer(fields, callback)
 pin.refundCharge(chargeId, fields, callback)
 pin.retrieveCharge(chargeId, callback)
 pin.createCharge(fields, callback)
+pin.captureCharge(uncapturedChargeToken, callback)
 ```
 
 ## Example

--- a/lib/pin.js
+++ b/lib/pin.js
@@ -105,12 +105,14 @@ var Pin = function(options) {
   this.getTransferLineItems = function(transferToken, callback){
     var req = request.get(options.url + '/1/transfers/' + transferToken+'/line_items');
     generateRequest(req,{},callback);
-  }
-  //Transfers
+  },
 
-  // this.createTransfer = function(fields){
-
-  // },
+  this.captureCharge = function (nonCapturedToken, callback) {
+    var url = options.url + '/1/charges/' + nonCapturedToken + "/capture";
+    console.log(url);
+    var req = request.put(url);
+    generateRequest(req, {}, callback);
+  };
 
 
 };

--- a/package.json
+++ b/package.json
@@ -11,8 +11,11 @@
     "superagent": "~0.9.4"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-things": "^0.2.0",
     "mocha": "~1.5.0",
-    "underscore" : "~1.7.0"
+    "moment": "^2.13.0",
+    "underscore": "~1.7.0"
   },
   "keywords": [
     "payment",


### PR DESCRIPTION
Hi,

I've added the capture charge endpoint so you can get pre-authorised charges captured. I also fixed some problems with the tests using outdated cards, and added tests in for the changes I made. All tests are passing.

- Adding a capture charge endpoint
- Adding capture charge tests
- Updating existing tests with a future date so they all pass
- Fixing input data on bank update test so it passes (using pin payments api test data)